### PR TITLE
Fix no-resolve issue for gatsby-node.js

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -126,6 +126,7 @@ exports.createPages = ({ graphql, boundActionCreators }) => {
         })
       })
     // === END TAGS ===
+    resolve()
   })
 }
 


### PR DESCRIPTION
This would just be stuck on createPages for hours. I left it overnight and it never finished, added this and it solved the problem